### PR TITLE
Fix deps and testing

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,6 +6,9 @@
   "author": "Riki Fridrich <riki@fczbkk.com> (http://fczbkk.com)",
   "license": "UNLICENSE",
   "main": "build/css-selector-generator.js",
+  "scripts": {
+    "test": "grunt dev"
+  },
   "devDependencies": {
     "coffeelint": "1.13.1",
     "grunt": "^0.4.5",

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
   "license": "UNLICENSE",
   "main": "build/css-selector-generator.js",
   "devDependencies": {
+    "coffeelint": "1.13.1",
     "grunt": "^0.4.5",
     "grunt-bump": "^0.6.0",
     "grunt-coffeelint": "^0.0.13",


### PR DESCRIPTION
* npm v3 does not install peer dependencies automatically any more, therefore an npm install fails due to: 
```
css-selector-generator@1.0.1 /Users/jfeth/dev/css-selector-generator
├── UNMET PEER DEPENDENCY coffeelint@^1
└── grunt-coffeelint@0.0.13

npm WARN EPEERINVALID grunt-coffeelint@0.0.13 requires a peer of coffeelint@^1 but none was installed.
npm WARN EPACKAGEJSON css-selector-generator@1.0.1 license should be a valid SPDX license expression
```
* Added test definition for running `npm test`.