### PR TITLE
fix: ignore empty IDs

### DIFF
--- a/build/css-selector-generator.js
+++ b/build/css-selector-generator.js
@@ -72,10 +72,11 @@
       if (id == null) {
         return false;
       }
-      if (/^\d/.exec(id)) {
+      try {
+        return document.querySelectorAll("#" + id).length === 1;
+      } catch (_error) {
         return false;
       }
-      return document.querySelectorAll("#" + id).length === 1;
     };
 
     CssSelectorGenerator.prototype.getIdSelector = function(element) {

--- a/src/css-selector-generator.coffee
+++ b/src/css-selector-generator.coffee
@@ -46,11 +46,11 @@ class CssSelectorGenerator
     # ID must exist
     return false unless id?
 
-    # ID can not start with number
-    return false if /^\d/.exec id
-
     # ID must be unique
-    return document.querySelectorAll("##{id}").length is 1
+    try
+      return document.querySelectorAll("##{id}").length is 1
+    catch
+      return false
 
   getIdSelector: (element) ->
     id = element.getAttribute 'id'

--- a/test/src/css-selector-generator.spec.coffee
+++ b/test/src/css-selector-generator.spec.coffee
@@ -147,6 +147,11 @@ describe 'CSS Selector Generator', ->
         root.innerHTML = '<div id="aaa"></div><div id="aaa"></div>'
         expect(x.validateId 'aaa').toBe false
 
+      it 'should ignore empty ID attributes (and other weirdnesses)', ->
+        root.innerHTML = '<div id=""></div>'
+        selector = x.getIdSelector root.firstChild
+        expect(document.querySelector selector).toBe null
+
     describe 'class', ->
 
       it 'should get class selectors for an element', ->


### PR DESCRIPTION
On empty IDs the selector generator would die with an exception, because `document.querySelectorAll('#')` is not valid.
I thought about adding a specific check for empty IDs, however there might be more edge cases I am not aware, so I just check for a thrown exception.

This PR adds a fix and a test that fails without the fix.