### PR TITLE
A bit of customizations

### DIFF
--- a/build/css-selector-generator.js
+++ b/build/css-selector-generator.js
@@ -6,7 +6,9 @@
     CssSelectorGenerator.prototype.default_options = {
       selectors: ['id', 'class', 'tag', 'nthchild'],
       prefix_tag: false,
-      log: false
+      log: false,
+      attribute_blacklist: [],
+      attribute_whitelist: []
     };
 
     function CssSelectorGenerator(options) {
@@ -107,14 +109,21 @@
     };
 
     CssSelectorGenerator.prototype.getAttributeSelectors = function(element) {
-      var attribute, blacklist, k, len, ref, ref1, result;
+      var a, attr, blacklist, k, l, len, len1, ref, ref1, ref2, result, whitelist;
       result = [];
-      blacklist = ['id', 'class'];
+      whitelist = this.options.attribute_whitelist;
+      for (k = 0, len = whitelist.length; k < len; k++) {
+        attr = whitelist[k];
+        if (element.hasAttribute(attr)) {
+          result.push("[" + attr + "=" + (this.sanitizeItem(element.getAttribute(attr))) + "]");
+        }
+      }
+      blacklist = this.options.attribute_blacklist.concat(['id', 'class']);
       ref = element.attributes;
-      for (k = 0, len = ref.length; k < len; k++) {
-        attribute = ref[k];
-        if (ref1 = attribute.nodeName, indexOf.call(blacklist, ref1) < 0) {
-          result.push("[" + attribute.nodeName + "=" + attribute.nodeValue + "]");
+      for (l = 0, len1 = ref.length; l < len1; l++) {
+        a = ref[l];
+        if (!((ref1 = a.nodeName, indexOf.call(blacklist, ref1) >= 0) || (ref2 = a.nodeName, indexOf.call(whitelist, ref2) >= 0))) {
+          result.push("[" + a.nodeName + "=" + (this.sanitizeItem(a.nodeValue)) + "]");
         }
       }
       return result;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "css-selector-generator",
-  "version": "1.0.4",
+  "version": "1.1.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -349,19 +349,25 @@
         }
       }
     },
+    "coffeescript": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/coffeescript/-/coffeescript-1.10.0.tgz",
+      "integrity": "sha1-56qDAZF+9iGzXYo580jc3R234z4=",
+      "dev": true
+    },
     "color-convert": {
-      "version": "1.9.2",
-      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.2.tgz",
-      "integrity": "sha512-3NUJZdhMhcdPn8vJ9v2UQJoH0qqoGUkYTgFEPZaPjEtwmmKUfNV46zZmgB2M5M4DCEQHMaCfWHCxiBflLm04Tg==",
+      "version": "1.9.3",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
+      "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
       "dev": true,
       "requires": {
-        "color-name": "1.1.1"
+        "color-name": "1.1.3"
       }
     },
     "color-name": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.1.tgz",
-      "integrity": "sha1-SxQVMEz1ACjqgWQ2Q72C6gWANok=",
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
+      "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
       "dev": true
     },
     "colors": {
@@ -1634,12 +1640,6 @@
         "rimraf": "~2.6.2"
       },
       "dependencies": {
-        "coffeescript": {
-          "version": "1.10.0",
-          "resolved": "https://registry.npmjs.org/coffeescript/-/coffeescript-1.10.0.tgz",
-          "integrity": "sha1-56qDAZF+9iGzXYo580jc3R234z4=",
-          "dev": true
-        },
         "glob": {
           "version": "7.0.6",
           "resolved": "https://registry.npmjs.org/glob/-/glob-7.0.6.tgz",
@@ -1929,9 +1929,9 @@
       }
     },
     "grunt-known-options": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/grunt-known-options/-/grunt-known-options-1.1.0.tgz",
-      "integrity": "sha1-pCdO6zL6dl2lp6OxcSYXzjsUQUk=",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/grunt-known-options/-/grunt-known-options-1.1.1.tgz",
+      "integrity": "sha512-cHwsLqoighpu7TuYj5RonnEuxGVFnztcUqTqp5rXFGYL4OuPFofwC4Ycg7n9fYwvK6F5WbYgeVOwph9Crs2fsQ==",
       "dev": true
     },
     "grunt-legacy-log": {
@@ -2088,9 +2088,9 @@
       }
     },
     "iconv-lite": {
-      "version": "0.4.23",
-      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.23.tgz",
-      "integrity": "sha512-neyTUVFtahjf0mB3dZT77u+8O0QB89jFdnBkd5P1JgYPbPaia3gXXOVL2fq8VyU2gMMD7SaN7QukTB/pmXYvDA==",
+      "version": "0.4.24",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
+      "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
       "dev": true,
       "requires": {
         "safer-buffer": ">= 2.1.2 < 3"
@@ -3188,9 +3188,9 @@
       "dev": true
     },
     "supports-color": {
-      "version": "5.4.0",
-      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.4.0.tgz",
-      "integrity": "sha512-zjaXglF5nnWpsq470jSv6P9DwPvgLkuapYmfDm3JWOm0vkNTVF2tI4UrN2r6jH1qM/uc/WtxYY1hYoA2dOKj5w==",
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+      "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
       "dev": true,
       "requires": {
         "has-flag": "^3.0.0"
@@ -3335,9 +3335,9 @@
       "dev": true
     },
     "underscore.string": {
-      "version": "3.3.4",
-      "resolved": "https://registry.npmjs.org/underscore.string/-/underscore.string-3.3.4.tgz",
-      "integrity": "sha1-LCo/n4PmR2L9xF5s6sZRQoZCE9s=",
+      "version": "3.3.5",
+      "resolved": "https://registry.npmjs.org/underscore.string/-/underscore.string-3.3.5.tgz",
+      "integrity": "sha512-g+dpmgn+XBneLmXXo+sGlW5xQEt4ErkS3mgeN2GFbremYeMBSJKr9Wf2KJplQVaiPY/f7FN6atosWYNm9ovrYg==",
       "dev": true,
       "requires": {
         "sprintf-js": "^1.0.3",

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   },
   "devDependencies": {
     "coffeelint": "1.15.7",
-    "grunt": "^1.0.1",
+    "grunt": "^1.0.3",
     "grunt-bump": "^0.8.0",
     "grunt-coffeelint": "^0.0.15",
     "grunt-contrib-coffee": "^1.0.0",

--- a/src/css-selector-generator.coffee
+++ b/src/css-selector-generator.coffee
@@ -3,7 +3,9 @@ class CssSelectorGenerator
   default_options:
     # choose from 'tag', 'id', 'class', 'nthchild', 'attribute'
     selectors: ['id', 'class', 'tag', 'nthchild'],
-    prefix_tag: false, log: false
+    prefix_tag: false, log: false,
+    attribute_blacklist: [],
+    attribute_whitelist: []
 
   constructor: (options = {}) ->
     @options = {}
@@ -82,10 +84,14 @@ class CssSelectorGenerator
 
   getAttributeSelectors: (element) ->
     result = []
-    blacklist = ['id', 'class']
-    for attribute in element.attributes
-      unless attribute.nodeName in blacklist
-        result.push "[#{attribute.nodeName}=#{attribute.nodeValue}]"
+    whitelist = @options.attribute_whitelist
+    for attr in whitelist
+      if element.hasAttribute attr
+        result.push "[#{attr}=#{@sanitizeItem element.getAttribute(attr)}]"
+    blacklist = @options.attribute_blacklist.concat(['id', 'class'])
+    for a in element.attributes
+      unless a.nodeName in blacklist or a.nodeName in whitelist
+        result.push "[#{a.nodeName}=#{@sanitizeItem a.nodeValue}]"
     result
 
   getNthChildSelector: (element) ->

--- a/test/src/css-selector-generator.spec.coffee
+++ b/test/src/css-selector-generator.spec.coffee
@@ -130,6 +130,12 @@ describe 'CSS Selector Generator', ->
         expect(x.getIdSelector elm).toBe '#linkZero'
         expect(x.getIdSelector root).toBe null
 
+      it 'should get ID selector for an element with tag', ->
+        x.setOptions prefix_tag: true
+        elm = root.querySelector '#linkZero'
+        expect(x.getIdSelector elm).toBe 'a#linkZero'
+        expect(x.getIdSelector root).toBe null
+
       it 'should escape special characters in ID selector', ->
         special_characters = '*+-./;'
         for special_character in special_characters.split ''
@@ -203,6 +209,11 @@ describe 'CSS Selector Generator', ->
         root.innerHTML = '<div class="aaa"></div>'
         expect(x.getSelector root.firstChild).toEqual '.aaa'
 
+      it 'should get element by class selector with tag', ->
+        x.setOptions selectors: ['class'], prefix_tag: true
+        root.innerHTML = '<div class="aaa"></div>'
+        expect(x.getSelector root.firstChild).toEqual 'div.aaa'
+
       it 'should combine class selector with tag selector if needed', ->
         x.setOptions selectors: ['tag', 'class']
         root.innerHTML = '
@@ -217,6 +228,11 @@ describe 'CSS Selector Generator', ->
         root.innerHTML = '<p class="aaa bbb"></p><p class="aaa ccc"></p>'
         expect(x.getSelector root.firstChild).toEqual '.bbb'
 
+      it 'should use single unique class when applicable with tag', ->
+        x.setOptions selectors: ['class'], prefix_tag: true
+        root.innerHTML = '<p class="aaa bbb"></p><p class="aaa ccc"></p>'
+        expect(x.getSelector root.firstChild).toEqual 'p.bbb'
+
       it 'should use combination of classes when applicable', ->
         x.setOptions selectors: ['class']
         root.innerHTML = '
@@ -225,6 +241,15 @@ describe 'CSS Selector Generator', ->
           <div class="bbb ccc"></div>
         '
         expect(x.getSelector root.firstChild).toEqual '.aaa.bbb'
+
+      it 'should use combination of classes when applicable with tag', ->
+        x.setOptions selectors: ['class' ], prefix_tag: true
+        root.innerHTML = '
+          <div class="aaa bbb"></div>
+          <div class="aaa ccc"></div>
+          <div class="bbb ccc"></div>
+        '
+        expect(x.getSelector root.firstChild).toEqual 'div.aaa.bbb'
 
     describe 'attribute', ->
 
@@ -244,10 +269,22 @@ describe 'CSS Selector Generator', ->
         result = x.getSelector root.firstChild
         expect(result).toEqual '[rel=aaa]'
 
+      it 'should use attribute selector when enabled with tag', ->
+        x.setOptions selectors: ['tag', 'id', 'class',
+                                 'attribute', 'nthchild'], prefix_tag: true
+        root.innerHTML = '<a rel="aaa"></a><a rel="bbb"></a>'
+        result = x.getSelector root.firstChild
+        expect(result).toEqual 'a[rel=aaa]'
+
       it 'should get element by attribute selector', ->
         x.setOptions selectors: ['attribute']
         root.innerHTML = '<a href="aaa"></a>'
         expect(x.getSelector root.firstChild).toEqual '[href=aaa]'
+
+      it 'should get element by attribute selector with tag', ->
+        x.setOptions selectors: ['attribute'], prefix_tag: true
+        root.innerHTML = '<a href="aaa"></a>'
+        expect(x.getSelector root.firstChild).toEqual 'a[href=aaa]'
 
       it 'should combine attribute selector with tag selector if needed', ->
         x.setOptions selectors: ['attribute', 'tag']
@@ -266,7 +303,15 @@ describe 'CSS Selector Generator', ->
         '
         expect(x.getSelector root.firstChild).toEqual '[rel=bbb]'
 
-      it 'should use combination of classes when applicable', ->
+      it 'should use single unique attribute when applicable with tag', ->
+        x.setOptions selectors: ['attribute'], prefix_tag: true
+        root.innerHTML = '
+          <a href="aaa" rel="bbb"></a>
+          <a href="aaa" rel="ccc"></a>
+        '
+        expect(x.getSelector root.firstChild).toEqual 'a[rel=bbb]'
+
+      it 'should use combination of attributes when applicable', ->
         x.setOptions selectors: ['attribute']
         root.innerHTML = '
           <a href="aaa" rel="aaa"></a>
@@ -275,12 +320,39 @@ describe 'CSS Selector Generator', ->
         '
         expect(x.getSelector root.firstChild).toEqual '[href=aaa][rel=aaa]'
 
+      it 'should use combination of attributes when applicable with tag', ->
+        x.setOptions selectors: ['attribute'], prefix_tag: true
+        root.innerHTML = '
+          <a href="aaa" rel="aaa"></a>
+          <a href="aaa" rel="xxx"></a>
+          <a href="xxx" rel="aaa"></a>
+        '
+        expect(x.getSelector root.firstChild).toEqual 'a[href=aaa][rel=aaa]'
+
+      it 'should use unique attribute from document', ->
+        x.setOptions selectors: ['attribute']
+        x.setOptions log:true
+        root.innerHTML = '
+            <div data-id="a1"><a id="aaa" href="aaa" rel="bbb">link1</a></div>
+            <div><a href="aaa" rel="aaa">link2</a></div>
+        '
+
+        elm = root.querySelector '#aaa'
+        expect(x.getSelector elm).
+                 toEqual '[rel=bbb]'
+
     describe 'n-th child', ->
 
       it 'should get n-th child selector for an element', ->
         elm = root.querySelector '#linkZero'
         result = x.getNthChildSelector elm
         expect(result).toBe ':nth-child(7)'
+
+      it 'should get n-th child selector for an element with tag', ->
+        x.setOptions prefix_tag: true
+        elm = root.querySelector '#linkZero'
+        result = x.getNthChildSelector elm
+        expect(result).toBe 'a:nth-child(7)'
 
 
   describe 'selector test', ->

--- a/test/src/css-selector-generator.spec.coffee
+++ b/test/src/css-selector-generator.spec.coffee
@@ -341,6 +341,45 @@ describe 'CSS Selector Generator', ->
         expect(x.getSelector elm).
                  toEqual '[rel=bbb]'
 
+      it 'should get attribute selectors for an element ignoring blacklist', ->
+        x.setOptions attribute_blacklist: [ 'href' ]
+        elm = root.querySelector '#linkZero'
+        result = x.getAttributeSelectors elm
+        expect(result).not.toContain '[href=linkThree]'
+        expect(result).toContain '[target=someTarget]'
+        expect(result).toContain '[rel=someRel]'
+        expect(result).not.toContain '[id=linkZero]'
+        expect(result.length).toBe 2
+        expect(x.getClassSelectors root).toEqual []
+
+      it 'should get attribute selectors prioritizing whitelist', ->
+        x.setOptions attribute_whitelist: [ 'rel' ]
+        elm = root.querySelector '#linkZero'
+        result = x.getAttributeSelectors elm
+        expect(result[0]).toEqual '[rel=someRel]'
+        expect(x.getClassSelectors root).toEqual []
+
+      it 'should sanitize attribute values', ->
+        x.setOptions selectors: ['attribute']
+        x.setOptions attribute_whitelist: ['href']
+        x.setOptions log:true
+        href = "https://www.google.co.in/" + \
+               "search?rlz=1C5CHFA_enIN755IN755&ei=wwPHW7OrOdv0rQHR-" + \
+               "KmABA&q=using+set+coffeescript&oq=using+set+coffeescript" + \
+               "&gs_l=psy-ab.3...2980.7444.0.7719.22." + \
+               "22.0.0.0.0.219.2518.0j15j2.17.0....0...1c.1.64.psy-ab..5" + \
+               ".15.2263...0" + \
+               "j0i131k1j0i67k1j0i131i67k1j0i22i30k1j33i22i29i30k1j33i21" + \
+               "k1j33i160k1." + \
+               "0.8WGhjkzVME4"
+        root.innerHTML = '<div data-id="a1"><a id="aaa" href=' + \
+                         "#{href}" + ' rel="bbb">link1</a></div>' + \
+                         '<div><a href="aaa" rel="aaa">link2</a></div>'
+
+        elm = root.querySelector '#aaa'
+        expect(x.getSelector elm).
+                 toEqual "[href=#{x.sanitizeItem href}]"
+
     describe 'n-th child', ->
 
       it 'should get n-th child selector for an element', ->

--- a/test/src/css-selector-generator.spec.coffee
+++ b/test/src/css-selector-generator.spec.coffee
@@ -331,7 +331,6 @@ describe 'CSS Selector Generator', ->
 
       it 'should use unique attribute from document', ->
         x.setOptions selectors: ['attribute']
-        x.setOptions log:true
         root.innerHTML = '
             <div data-id="a1"><a id="aaa" href="aaa" rel="bbb">link1</a></div>
             <div><a href="aaa" rel="aaa">link2</a></div>
@@ -362,7 +361,7 @@ describe 'CSS Selector Generator', ->
       it 'should sanitize attribute values', ->
         x.setOptions selectors: ['attribute']
         x.setOptions attribute_whitelist: ['href']
-        x.setOptions log:true
+
         href = "https://www.google.co.in/" + \
                "search?rlz=1C5CHFA_enIN755IN755&ei=wwPHW7OrOdv0rQHR-" + \
                "KmABA&q=using+set+coffeescript&oq=using+set+coffeescript" + \
@@ -379,6 +378,38 @@ describe 'CSS Selector Generator', ->
         elm = root.querySelector '#aaa'
         expect(x.getSelector elm).
                  toEqual "[href=#{x.sanitizeItem href}]"
+
+      it 'should sanitize attribute values with quotes', ->
+        x.setOptions selectors: ['attribute']
+        x.setOptions attribute_whitelist: ['href']
+        x.setOptions quote_attribute_when_needed: true
+        x.setOptions log:true
+
+        href = "https'://www.google.co.in/" + \
+               "search?rlz=1C5CHFA_enIN755IN755&ei=wwPHW7OrOdv0rQHR-" + \
+               "KmABA&q=using+set+coffeescript&oq=using+set+coffeescript" + \
+               "&gs_l=psy-ab.3...2980.7444.0.7719.22." + \
+               "22.0.0.0.0.219.2518.0j15j2.17.0....0...1c.1.64.psy-ab..5" + \
+               ".15.2263...0" + \
+               "j0i131k1j0i67k1j0i131i67k1j0i22i30k1j33i22i29i30k1j33i21" + \
+               "k1j33i160k1." + \
+               "0.8WGhjkzVME4"
+        href_expected = "https\\'://www.google.co.in/" + \
+               "search?rlz=1C5CHFA_enIN755IN755&ei=wwPHW7OrOdv0rQHR-" + \
+               "KmABA&q=using+set+coffeescript&oq=using+set+coffeescript" + \
+               "&gs_l=psy-ab.3...2980.7444.0.7719.22." + \
+               "22.0.0.0.0.219.2518.0j15j2.17.0....0...1c.1.64.psy-ab..5" + \
+               ".15.2263...0" + \
+               "j0i131k1j0i67k1j0i131i67k1j0i22i30k1j33i22i29i30k1j33i21" + \
+               "k1j33i160k1." + \
+               "0.8WGhjkzVME4"
+        root.innerHTML = '<div data-id="a1"><a id="aaa" href=' + \
+                         "#{href}" + ' rel="bbb">link1</a></div>' + \
+                         '<div><a href="aaa" rel="aaa">link2</a></div>'
+
+        elm = root.querySelector '#aaa'
+        expect(x.getSelector elm).
+                 toEqual "[href='#{href_expected}']"
 
     describe 'n-th child', ->
 


### PR DESCRIPTION
Hello,

I have been looking for a CSS selector generator for one of my projects and found this one. My requirement is that the selector generated should be human-readable. For this purpose, I added some options to make the generator configurable.

Specifically:

1. Added a prefix_tag option
2. Added attribute_whitelist and attribute_blacklist. Blacklisted attributes are ignored and whitelisted attributes are given priority when generating attribute selectors.
3. Fixed sanitising the attribute values
4. Added quote_attribute_when_needed option.
5. Added id_blacklist and class_blacklist that take either strings or regexes.

When not configured using the new options (except for (3)) the behavior is the same.