### PR TITLE
Fix nth of type

### DIFF
--- a/src/selector-nth-of-type.js
+++ b/src/selector-nth-of-type.js
@@ -7,16 +7,6 @@ import {getTagSelector} from './selector-tag';
  */
 export function getNthOfTypeSelector (element) {
   const tag = getTagSelector(element)[0];
-  const parentElement = element.parentElement;
-
-  if (parentElement) {
-    const siblings = parentElement.querySelectorAll(tag);
-    for (let i = 0; i < siblings.length; i++) {
-      if (siblings[i] === element) {
-        return [`${tag}:nth-of-type(${i + 1})`];
-      }
-    }
-  }
-
-  return [];
+  const index = [...element.parentElement.children].filter(node => node.tagName.toLowerCase() === tag).indexOf(element) + 1;
+  return [`${tag}:nth-of-type(${index})`];
 }

--- a/src/selector-nth-of-type.js
+++ b/src/selector-nth-of-type.js
@@ -7,6 +7,11 @@ import {getTagSelector} from './selector-tag';
  */
 export function getNthOfTypeSelector (element) {
   const tag = getTagSelector(element)[0];
-  const index = [...element.parentElement.children].filter(node => node.tagName.toLowerCase() === tag).indexOf(element) + 1;
-  return [`${tag}:nth-of-type(${index})`];
+  const parentElement = element.parentElement;
+  if (parentElement) {
+    const index = [...parentElement.children].filter(node => node.tagName.toLowerCase() === tag).indexOf(element) + 1;
+    return [`${tag}:nth-of-type(${index})`];
+  }
+
+  return [];
 }

--- a/src/selector-nth-of-type.js
+++ b/src/selector-nth-of-type.js
@@ -9,7 +9,10 @@ export function getNthOfTypeSelector (element) {
   const tag = getTagSelector(element)[0];
   const parentElement = element.parentElement;
   if (parentElement) {
-    const index = [...parentElement.children].filter(node => node.tagName.toLowerCase() === tag).indexOf(element) + 1;
+    const siblings = [...parentElement.children].filter(node => {
+      return node.tagName.toLowerCase() === tag
+    });
+    const index = siblings.indexOf(element) + 1;
     return [`${tag}:nth-of-type(${index})`];
   }
 

--- a/test/selector-nth-of-type.spec.js
+++ b/test/selector-nth-of-type.spec.js
@@ -30,6 +30,15 @@ describe('selector - nth-of-type', function () {
     assert.equal(result, 'div:nth-of-type(1)');
   });
 
+  it('should ignore nested elements', function () {
+    root.innerHTML = '<ul><li><a></a></li><li><a></a><ul><li><a></a></li></ul></li><li><a id="link2"></a></li></ul>';
+    const result = getCssSelector(root.querySelector('#link2'), {
+      selectors: ['nthoftype'],
+      root,
+    });
+    assert.equal(result, 'li:nth-of-type(3) > a:nth-of-type(1)');
+  });
+
   it('should not collide with tag selector', function () {
     root.innerHTML = '<div></div><p></p><p></p>';
     const result = getCssSelector(root.lastChild, {


### PR DESCRIPTION
The current implementation of nth of type is not working correctly when there are more similar tags deeper down. Example:
```
<ul>
<li><a>Link 1</a></li>
<li>
    <a>Submenu</a>
    <ul><li><a>Sublink</a></li></ul>
</li>
<li><a>Link 2</a></li>
</ul>
```

In this case, the correct :nth-of-type of the `<li>` of the Link 2, would be 2 because only siblings are considered (as per https://developer.mozilla.org/en-US/docs/Web/CSS/:nth-of-type), but because in the previous implementation querySelectorAll(tag) was used, it was also considering the deeper nested elements so it would return :nth-of-type(3) instead of :nth-of-type(2).

