### PR TITLE
Fix the situation when both nthoftype and tag are combined

### DIFF
--- a/src/utilities-selectors.js
+++ b/src/utilities-selectors.js
@@ -246,10 +246,10 @@ export function constructSelectorType (selector_type, selectors_data) {
  * @return {string}
  */
 export function constructSelector (selector_data = {}) {
-  const pattern = [...SELECTOR_PATTERN]
+  const pattern = [...SELECTOR_PATTERN];
   // Both tag and nthoftype should not be used as they will cause an invalid selector
   if (selector_data['tag'] && selector_data['nthoftype']) {
-    pattern.splice(pattern.indexOf('tag'), 1)
+    pattern.splice(pattern.indexOf('tag'), 1);
   }
 
   return pattern

--- a/src/utilities-selectors.js
+++ b/src/utilities-selectors.js
@@ -246,7 +246,13 @@ export function constructSelectorType (selector_type, selectors_data) {
  * @return {string}
  */
 export function constructSelector (selector_data = {}) {
-  return SELECTOR_PATTERN
+  const pattern = [...SELECTOR_PATTERN]
+  // Both tag and nthoftype should not be used as they will cause an invalid selector
+  if (selector_data['tag'] && selector_data['nthoftype']) {
+    pattern.splice(pattern.indexOf('tag'), 1)
+  }
+
+  return pattern
     .map((type) => constructSelectorType(type, selector_data))
     .join('');
 }

--- a/test/selector-nth-of-type.spec.js
+++ b/test/selector-nth-of-type.spec.js
@@ -21,6 +21,15 @@ describe('selector - nth-of-type', function () {
     assert.equal(result[0], 'p:nth-of-type(2)');
   });
 
+  it('should not throw error if tag and nthoftype used', function () {
+    root.innerHTML = '<ul><li><a></a></li><li><a></a><ul><li></li><li></li></ul></li></ul>';
+    const result = getCssSelector(root.querySelector('a'), {
+      selectors: ['tag', 'nthoftype'],
+      root,
+    });
+    assert.equal(result, ':nth-child(1) > :nth-child(1) > :nth-child(1)');
+  });
+
   it('should not collide with tag selector', function () {
     root.innerHTML = '<div></div><p></p><p></p>';
     const result = getCssSelector(root.lastChild, {


### PR DESCRIPTION
In certain situations an invalid selector was generated when using both `tag` and `nthoftype` selectors like this (if combineWithin Selector = true):
```
li:nth-of-type(1)li
```

I have made an adjustment to exclude the `tag` from the pattern order if there is already a `nthoftype` selector.

