### PR TITLE
Add failing test case for shadow DOM selector generation

### DIFF
--- a/test/failing-shadow-dom.spec.js
+++ b/test/failing-shadow-dom.spec.js
@@ -1,0 +1,39 @@
+import {assert} from 'chai'
+import {getCssSelector} from '../src/index.ts'
+
+describe('Shadow DOM', () => {
+  let root
+  let shadowRoot
+  let shadowElement
+  let shadowElementChildParagraph
+  let shadowElementChildDiv
+
+  beforeEach(() => {
+    root = document.body.appendChild(document.createElement('div'))
+    shadowRoot = root.attachShadow({mode: 'open'})
+    shadowElement = shadowRoot.appendChild(document.createElement('div'))
+    shadowElement.id = 'shadow-content'
+    shadowElementChildParagraph = shadowElement.appendChild(document.createElement('p'))
+    shadowElementChildDiv = shadowElement.appendChild(document.createElement('div'))
+    shadowElementChildDiv.id = 'nested-shadow-host'
+  })
+
+  afterEach(() => {
+    root.parentNode.removeChild(root)
+  })
+
+  it('should match shadow element within shadow root', () => {
+    const result = getCssSelector(shadowElement, {root: shadowRoot})
+    assert.equal(result, '#shadow-content')
+  })
+
+  it('should match shadow element\'s child paragraph within shadow root', () => {
+    const result = getCssSelector(shadowElementChildParagraph, {root: shadowRoot})
+    assert.equal(result, 'p')
+  })
+
+  it('should match shadow element\'s child div within shadow root', () => {
+    const result = getCssSelector(shadowElementChildDiv, {root: shadowRoot})
+    assert.equal(result, '#nested-shadow-host')
+  })
+})


### PR DESCRIPTION
Related to #173 

```
SUMMARY:
✔ 105 tests completed
ℹ 1 test skipped
✖ 2 tests failed

FAILED TESTS:
  Shadow DOM
    ✖ should match shadow element within shadow root
      Chrome Headless 96.0.4664.110 (Mac OS 10.15.7)
    AssertionError: expected ':root > :nth-child(1)' to equal '#shadow-content'
        at Context.<anonymous> (/Users/niranjan/Development/grouped/mockingjay/mockingjay-core/tmp/css-selector-generator/temp/commons.js:12769:46)

    ✖ should match shadow element's child div within shadow root
      Chrome Headless 96.0.4664.110 (Mac OS 10.15.7)
    AssertionError: expected ':root > :nth-child(1) > :nth-child(2)' to equal '#nested-shadow-host'
        at Context.<anonymous> (/Users/niranjan/Development/grouped/mockingjay/mockingjay-core/tmp/css-selector-generator/temp/commons.js:12779:46)
```