### PR TITLE
Accept function as `CssSelectorMatch`

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -48,7 +48,8 @@ export interface ResultData {
 export type CssSelector = string
 export type CssSelectors = Array<CssSelector>
 
-export type CssSelectorMatch = RegExp | string
+export type SelectorPredicateFunction = (selector: string) => boolean;
+export type CssSelectorMatch = RegExp | string | SelectorPredicateFunction;
 
 export enum CssSelectorType {
   id = 'id',

--- a/src/utilities-data.ts
+++ b/src/utilities-data.ts
@@ -1,5 +1,4 @@
 import {CssSelectorMatch, PatternMatcher} from './types'
-import {isRegExp} from './utilities-options'
 
 /**
  * Creates array containing only items included in all input arrays.
@@ -40,9 +39,12 @@ export function createPatternMatcher (
   list: CssSelectorMatch[]
 ): PatternMatcher {
   const patterns = list.map(
-    (item) => (isRegExp(item)
-      ? item
-      : new RegExp('^' + wildcardToRegExp(item) + '$'))
+    (item) =>
+      (typeof item === 'string'
+        ? new RegExp('^' + wildcardToRegExp(item) + '$')
+        : item)
   )
-  return (input: string) => patterns.some((re) => re.test(input))
+  return (input: string) =>
+    patterns.some((pattern) =>
+      (typeof pattern === 'function' ? pattern(input) : pattern.test(input)))
 }

--- a/src/utilities-options.ts
+++ b/src/utilities-options.ts
@@ -48,7 +48,9 @@ export function isRegExp (input: unknown): input is RegExp {
  * @param input
  */
 export function isCssSelectorMatch (input: unknown): input is CssSelectorMatch {
-  return (typeof input === 'string') || isRegExp(input)
+  return (
+    typeof input === 'string' || typeof input === 'function' || isRegExp(input)
+  )
 }
 
 /**

--- a/test/options-blacklist.spec.js
+++ b/test/options-blacklist.spec.js
@@ -31,6 +31,14 @@ describe('options: blacklist', function () {
     assert.equal(result, '.bbb')
   })
 
+  it('should use functions as predicates', function () {
+    root.innerHTML = '<div class="aaa bbb"></div>'
+    const result = getCssSelector(root.firstElementChild, {
+      blacklist: [(selector) => selector.endsWith('aa')]
+    })
+    assert.equal(result, '.bbb')
+  })
+
   it('should work with multiple items', function () {
     root.innerHTML = '<div class="aaa bbb"></div>'
     const result = getCssSelector(

--- a/test/options-whitelist.spec.js
+++ b/test/options-whitelist.spec.js
@@ -31,6 +31,14 @@ describe('options: whitelist', function () {
     assert.equal(result, '.bbb')
   })
 
+  it('should use functions as predicates', function () {
+    root.innerHTML = '<div class="aaa bbb"></div>'
+    const result = getCssSelector(root.firstElementChild, {
+      whitelist: [(selector) => selector.endsWith('bb')]
+    })
+    assert.equal(result, '.bbb')
+  })
+
   it('should work with multiple items', function () {
     root.innerHTML = '<div class="aaa bbb"></div>'
     const result = getCssSelector(


### PR DESCRIPTION
- Closes https://github.com/fczbkk/css-selector-generator/issues/212

I went ahead and tried to implement the suggested feature. Let me know what you think.

Side note: running `npm run build` will clear the `types` folder and I don't see how to re-generate them.