### PR TITLE
Add support for IDs and classes starting with a number

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -25,13 +25,11 @@ export const SELECTOR_SEPARATOR = ', '
 export const INVALID_ID_RE = new RegExp([
   '^$', // empty or not set
   '\\s', // contains whitespace
-  '^\\d' // begins with a number
 ].join('|'))
 
 // RegExp that will match invalid patterns that can be used in class attribute.
 export const INVALID_CLASS_RE = new RegExp([
   '^$', // empty or not set
-  '^\\d' // begins with a number
 ].join('|'))
 
 // Order in which a combined selector is constructed.

--- a/test/selector-class.spec.js
+++ b/test/selector-class.spec.js
@@ -56,11 +56,10 @@ describe('selector - class', function () {
     assert.include(result, '.aaa\\:bbb')
   })
 
-  it('should ignore class names that start with a number', function () {
+  it('should escape class names that start with a number', function () {
     root.innerHTML = '<div class="1 1a a1"></div>'
     const result = getClassSelectors([root.firstElementChild])
-    assert.lengthOf(result, 1)
-    assert.include(result, '.a1')
+    assert.sameMembers(result, ['.\\31 ', '.\\31 a', '.a1'])
   })
 
   it('should generate class selectors for multiple elements', () => {

--- a/test/selector-id.spec.js
+++ b/test/selector-id.spec.js
@@ -33,9 +33,9 @@ describe('selector - ID', function () {
     assert.deepEqual(getIdSelector([root.firstElementChild]), ['#aaa\\:bbb'])
   })
 
-  it('should ignore ID beginning with a number', function () {
+  it('should escape ID beginning with a number', function () {
     root.innerHTML = '<div id="1aaa"></div>'
-    assert.deepEqual(getIdSelector([root.firstElementChild]), [])
+    assert.deepEqual(getIdSelector([root.firstElementChild]), ['#\\31 aaa'])
   })
 
   it('should ignore non-unique ID attribute', function () {


### PR DESCRIPTION
- Reverts fix for https://github.com/fczbkk/css-selector-generator/issues/37

While awkward and unusual, class and ID selectors _can_ start with a number: https://mothereff.in/css-escapes#01a