### PR TITLE
Fix exports map in TypeScript

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,14 +8,12 @@
   "type": "module",
   "main": "build/index.js",
   "exports": {
-    "import": {
+    ".": {
       "types": "./types/index.d.ts",
-      "default": "./esm/index.js"
+      "import": "./esm/index.js",
+      "require": "./build/index.js"
     },
-    "require":  {
-      "types": "./types/index.d.ts",
-      "default": "./build/index.js"
-    }
+    "./types/*": "./types/*"
   },
   "module": "./esm/index.js",
   "types": "types/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -8,8 +8,14 @@
   "type": "module",
   "main": "build/index.js",
   "exports": {
-    "import": "./esm/index.js",
-    "require": "./build/index.js"
+    "import": {
+      "types": "./types/index.d.ts",
+      "default": "./esm/index.js"
+    },
+    "require":  {
+      "types": "./types/index.d.ts",
+      "default": "./build/index.js"
+    }
   },
   "module": "./esm/index.js",
   "types": "types/index.d.ts",


### PR DESCRIPTION
When using newer `moduleResolution` settings like `node16` and `bundler`, TypeScript is not able to access any files that are not specified in the `exports` map. This should fix the issue.