### PR TITLE
feat: escape attribute selectors

### DIFF
--- a/src/selector-attribute.ts
+++ b/src/selector-attribute.ts
@@ -16,10 +16,15 @@ export const attributeBlacklistMatch = createPatternMatcher([
 ]);
 
 /**
- * Prevents errors when attribute name contains a colon (e.g. "xlink:href").
+ * Prevents errors when attribute name contains special characters, such as colons or semicolons
+ * (e.g. "xlink:href").
  */
 function sanitizeAttributeName (name: string) {
-  return CSS.escape(name);
+  if (CSS.escape) {
+    CSS.escape(name);
+  }
+
+  return name.replace(/([;:])/g, "\\$1");
 }
 
 /**

--- a/src/selector-attribute.ts
+++ b/src/selector-attribute.ts
@@ -19,7 +19,7 @@ export const attributeBlacklistMatch = createPatternMatcher([
  * Prevents errors when attribute name contains a colon (e.g. "xlink:href").
  */
 function sanitizeAttributeName (name: string) {
-  return name.replace(/:/g, "\\:");
+  return CSS.escape(name);
 }
 
 /**

--- a/test/selector-attribute.spec.js
+++ b/test/selector-attribute.spec.js
@@ -127,4 +127,11 @@ describe("selector - attribute", function () {
       assert.equal(document.querySelector(selector), element)
     })
   });
+
+  it('should escape attributes containing semi-colons', () => {
+    root.innerHTML = '<div aaa;bbb="ccc" />'
+    const element = root.firstElementChild
+    const result = getCssSelector(element)
+    assert.equal(result, '[aaa\\;bbb]')
+  });
 });


### PR DESCRIPTION
## What was changed?
 - Replaces single escape rule for colon `:` -> `\\:` with `CSS.escape`
 - adds unit test for escaping semi colon `;` -> `\\;`