### PR TITLE
fix: correct element detection for iframe compatibility

### DIFF
--- a/src/utilities-iselement.ts
+++ b/src/utilities-iselement.ts
@@ -2,5 +2,5 @@
  * Guard function that checks if provided `input` is an Element.
  */
 export function isElement(input: unknown): input is Element {
-  return input && input instanceof Element;
+  return input && input.nodeType === Node.ELEMENT_NODE;
 }


### PR DESCRIPTION
**🚨 Issue:**
`getCssSelector` throws errors when applied to iframe elements.

**🛠️ Fix:**
Replacing `instanceof` with `Node.ELEMENT_NODE` resolves this issue. Unlike `instanceof`, `Node.ELEMENT_NODE` isn't context-dependent, ensuring consistent behavior across documents.
